### PR TITLE
Add argument to register method, `override`

### DIFF
--- a/src/numeral.js
+++ b/src/numeral.js
@@ -452,10 +452,10 @@
         options.defaultFormat = typeof(format) === 'string' ? format : '0.0';
     };
 
-    numeral.register = function(type, name, format) {
+    numeral.register = function(type, name, format, override) {
         name = name.toLowerCase();
 
-        if (this[type + 's'][name]) {
+        if (this[type + 's'][name] && !override) {
             throw new TypeError(name + ' ' + type + ' already registered.');
         }
 


### PR DESCRIPTION
Otherwise you cannot override the percentage format, like showing here: http://numeraljs.com/#custom-formats